### PR TITLE
메인 페이지 교훈 스타일 수정

### DIFF
--- a/src/pages/Main/style.js
+++ b/src/pages/Main/style.js
@@ -88,6 +88,7 @@ export const Lesson = styled.div`
   background-color: #f1f1f5;
   border-left: 8px solid #007eff;
   width: 300px;
+  text-align: center;
 `;
 
 export const SchoolSonContainer = styled.div`


### PR DESCRIPTION
## 작업 내용 
- 교훈을 가운데 정렬했습니다!
<img width="423" alt="image" src="https://github.com/Gmu-Wiki/Gmu-WiKi-Front-V2/assets/103751430/271b4cfc-acd6-4aa3-a22d-173c2245bd80">
