### PR TITLE
디테일 (토글) 컴포넌트 스타일 수정

### DIFF
--- a/src/components/Detail/style.js
+++ b/src/components/Detail/style.js
@@ -14,6 +14,7 @@ export const DetailNumber = styled.span`
   color: #007eff;
   opacity: ${props => (!props.detailActive ? 0.5 : 1)};
   font-weight: 600;
+  margin-right: 8px;
 `;
 
 export const DetailTitle = styled.span`


### PR DESCRIPTION
## 작업 내용
- 디테일 컴포넌트에서 숫자와 텍스트 사이 간격을 수정했습니다.
<img width="523" alt="image" src="https://github.com/Gmu-Wiki/Gmu-WiKi-Front-V2/assets/103751430/55d6a857-8dfa-4fc3-9a45-4a048c86d711">
