### PR TITLE
서비스의 XSS 취약점 문제를 보완했습니다.

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@testing-library/user-event": "^13.5.0",
     "@vercel/analytics": "^1.0.2",
     "axios": "^1.4.0",
+    "dompurify": "^3.0.5",
     "jsonwebtoken": "^9.0.1",
     "jwt-decode": "^3.1.2",
     "marked": "^5.1.0",

--- a/src/components/BoardDetail/index.jsx
+++ b/src/components/BoardDetail/index.jsx
@@ -1,11 +1,14 @@
 import React from "react";
 import * as S from "./style";
 import useMarkdown from "../../Hooks/useMarkdown";
+import DOMPurify from "dompurify";
 
 const BoardDetailItem = ({ content, createdDate, editedDate }) => {
   const { markdownToHtml } = useMarkdown();
 
   const html = markdownToHtml(content);
+
+  const cleanHtml = DOMPurify.sanitize(html);
 
   return (
     <>
@@ -14,7 +17,7 @@ const BoardDetailItem = ({ content, createdDate, editedDate }) => {
         <S.Date>최근 수정 시각 : {editedDate}</S.Date>
       </S.NTBox>
 
-      <S.Content dangerouslySetInnerHTML={{ __html: html }} />
+      <S.Content dangerouslySetInnerHTML={{ __html: cleanHtml }} />
     </>
   );
 };

--- a/src/components/HistoryDetailItem/index.jsx
+++ b/src/components/HistoryDetailItem/index.jsx
@@ -1,18 +1,22 @@
 import React from "react";
 import useMarkdown from "../../Hooks/useMarkdown";
 import * as S from "./style";
+import DOMPurify from "dompurify";
 
 const HistoryDetailItem = ({ content, createdDate }) => {
   const { markdownToHtml } = useMarkdown();
 
   const html = markdownToHtml(content);
+
+  const cleanHtml = DOMPurify.sanitize(html);
+
   return (
     <>
       <S.NTBox>
         <S.Date>생성 일자 : {createdDate}</S.Date>
       </S.NTBox>
 
-      <S.Content dangerouslySetInnerHTML={{ __html: html }} />
+      <S.Content dangerouslySetInnerHTML={{ __html: cleanHtml }} />
     </>
   );
 };

--- a/src/components/InquiryDetailItem/index.jsx
+++ b/src/components/InquiryDetailItem/index.jsx
@@ -3,6 +3,7 @@ import * as S from "./style";
 import * as C from "../index";
 import { useMail } from "../../Hooks";
 import useMarkdown from "../../Hooks/useMarkdown";
+import DOMPurify from "dompurify";
 
 const InquiryDetailItem = ({ id, content, name, inquiryType, createdDate }) => {
   const { postApproveMail } = useMail({ props: { id } });
@@ -25,13 +26,15 @@ const InquiryDetailItem = ({ id, content, name, inquiryType, createdDate }) => {
 
   const html = markdownToHtml(content);
 
+  const cleanHtml = DOMPurify.sanitize(html);
+
   return (
     <>
       <S.NTBox>
         <S.Name>작성자 : {name}</S.Name>
         <S.CreatedDate>작성일 : {createdDate}</S.CreatedDate>
       </S.NTBox>
-      <S.Content dangerouslySetInnerHTML={{ __html: html }} />
+      <S.Content dangerouslySetInnerHTML={{ __html: cleanHtml }} />
       {showRefusal && (
         <C.Refusal
           id={id}

--- a/src/components/NoticeDetail/index.jsx
+++ b/src/components/NoticeDetail/index.jsx
@@ -1,11 +1,14 @@
 import React from "react";
 import * as S from "./style";
 import useMarkdown from "../../Hooks/useMarkdown";
+import DOMPurify from "dompurify";
 
 const NoticeDetailItem = ({ id, content, createdDate, editedDate }) => {
   const { markdownToHtml } = useMarkdown();
 
   const html = markdownToHtml(content);
+
+  const cleanHtml = DOMPurify.sanitize(html);
 
   return (
     <>
@@ -14,7 +17,7 @@ const NoticeDetailItem = ({ id, content, createdDate, editedDate }) => {
         <S.Date>수정일 : {editedDate}</S.Date>
       </S.NTBox>
 
-      <S.Content dangerouslySetInnerHTML={{ __html: html }} />
+      <S.Content dangerouslySetInnerHTML={{ __html: cleanHtml }} />
     </>
   );
 };

--- a/src/components/WriteBox/PreviewWriteBox/MarkdownConverter/index.jsx
+++ b/src/components/WriteBox/PreviewWriteBox/MarkdownConverter/index.jsx
@@ -1,15 +1,18 @@
 import useMarkdown from "../../../../Hooks/useMarkdown";
+import DOMPurify from "dompurify";
 
 function MarkDownConverter({ value }) {
   const { markdownToHtml } = useMarkdown();
 
   const html = markdownToHtml(value);
 
+  const cleanHtml = DOMPurify.sanitize(html);
+
   return (
     <>
       <div
         className="markdownConverter"
-        dangerouslySetInnerHTML={{ __html: html }}
+        dangerouslySetInnerHTML={{ __html: cleanHtml }}
       />
     </>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -3990,6 +3990,11 @@ domhandler@^4.0.0, domhandler@^4.2.0, domhandler@^4.3.1:
   dependencies:
     domelementtype "^2.2.0"
 
+dompurify@^3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.0.5.tgz#eb3d9cfa10037b6e73f32c586682c4b2ab01fbed"
+  integrity sha512-F9e6wPGtY+8KNMRAVfxeCOHU0/NPWMSENNq4pQctuXRqqdEPW7q3CrLbR5Nse044WwacyjHGOMlvNsBe1y6z9A==
+
 domutils@^1.7.0:
   version "1.7.0"
   resolved "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz"


### PR DESCRIPTION
## issue

https://www.gmuwiki.com/board/2831/record/detail 

7기 정상혁 학생이 수정한 문서입니다.

현재 해당 문서 접속 시, youtube shorts 링크로 이동 되고 있습니다.

element를 살펴보면, 

<img width="512" alt="스크린샷 2023-09-14 오후 1 59 09" src="https://github.com/Gmu-Wiki/Gmu-WiKi-Front-V2/assets/80103328/3ff040a0-886d-4a4c-82d3-3325bfe8ba42">

위와 같이 img 태그의 src에 정상적이지 않은 값을 넣어 error를 유도하고, 
onerror property에 script를 넣는 방식으로 해당 문제가 발생하고 있습니다.

## 해결

위 문제를 해결하기 위해,

<img width="487" alt="스크린샷 2023-09-14 오후 2 28 51" src="https://github.com/Gmu-Wiki/Gmu-WiKi-Front-V2/assets/80103328/a921e866-44df-40aa-ad7a-4718e1cd4c1d">

[DOMPurify](https://github.com/cure53/DOMPurify) 를 사용하여, `markdownToHtml`에서 return 된 html의 공격 가능성이 있는 부분들을 제거한 후 (Sanitize) _dangerouslySetInnerHTML에 넘겨줍니다.

해당 코드 적용 이후, 해당 문서의 elements를 살펴보면

<img width="277" alt="스크린샷 2023-09-14 오후 1 58 57" src="https://github.com/Gmu-Wiki/Gmu-WiKi-Front-V2/assets/80103328/b652265d-f014-455f-9030-883e6bbbba06">

위와 같이 기존의 공격에 사용되던 코드가 제거 된 것을 확인하실 수 있으시고, 기존에 발생하던 문제 또한 더 이상 발생하지 않습니다.

