### PR TITLE
글의 이미지 크기 조정

### DIFF
--- a/src/styles/GlobalStyle.jsx
+++ b/src/styles/GlobalStyle.jsx
@@ -191,8 +191,9 @@ details summary::before {
   }
 
   img {
-    max-width: 80vw;
-    max-height: 80vh;
+    display: block;
+    max-width: 100%;
+    max-height: 80%;
     object-fit: cover;
 
     @media screen and (max-width: 1280px) {


### PR DESCRIPTION
글에서 크기가 viewport 기준으로 돼 있어 글 컨테이너 크기를 벗어났습니다.

<img width="1787" alt="image" src="https://github.com/Gmu-Wiki/Gmu-WiKi-Front-V2/assets/105215297/6fd4c0d7-6ebd-4c26-9ff1-9459a53aa15b">
<img width="1568" alt="image" src="https://github.com/Gmu-Wiki/Gmu-WiKi-Front-V2/assets/105215297/9ec5899c-2b9a-4f71-995a-cc9d83e46a17">

- img는 무조건 아래로 내려가도록 display: block; 적용
- vw -> %