### PR TITLE
툴바에서 토글 옵션 수정

### DIFF
--- a/src/components/WriteOption/index.jsx
+++ b/src/components/WriteOption/index.jsx
@@ -69,7 +69,7 @@ function WriteOption({ content, setContent, textareaRef, setNumArr }) {
         numArr.length + 2,
         numArr.length + 3
       ]);
-      addOption(">>\n" + ">==제목==<\n" + "(텍스트)\n" + "<<");
+      addOption(">>\n" + ">==제목==<\n" + "\n___\n\n" + "(텍스트)\n" + "<<");
     } else if (option === "quote") {
       addOption("> 텍스트");
     } else if (option === "a") {


### PR DESCRIPTION
툴바에서 토글을 선택했을 때 구분선이 나타나지 않았습니다.
<img width="1256" alt="image" src="https://github.com/Gmu-Wiki/Gmu-WiKi-Front-V2/assets/105215297/4379cb80-46dc-4548-abec-e9411c7aabef">
<img width="1246" alt="image" src="https://github.com/Gmu-Wiki/Gmu-WiKi-Front-V2/assets/105215297/50d4aae3-091c-43cf-8469-68c0a4ad2373">
